### PR TITLE
Use node crypto for random bytes

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "bcrypt": "^5.0.0",
     "crypto-js": "^3.1.9-1",
-    "locutus": "^2.0.10",
-    "randbytes": "0.0.1"
+    "locutus": "^2.0.10"
   }
 }

--- a/password-hash.js
+++ b/password-hash.js
@@ -30,7 +30,6 @@
  * IN THE SOFTWARE. 
  */
 
-const RandBytes = new require('randbytes');
 const bcrypt = require('bcrypt');
 const crypto = require('crypto');
 const cryptoJS = require('crypto-js');
@@ -64,20 +63,21 @@ class PasswordHash {
     }
 
     /**
-     * Only works on Unix like because use /dev/urandom
-     * 
-     * @param {integer} count 
+     * Get cryptographically strong pseudorandom bytes 
+     *
+     * @param {integer} count
      * @return {Promise}
      */
     get_random_bytes(count) {
-        const promise = new Promise((resolve, reject) => {
-            let output = '';
-            const randomSource = RandBytes.urandom.getInstance();
-            randomSource.getRandomBytes(count, function (buff) {
-                resolve(buff.toString('binary'));
-            });
-        });
-        return promise;
+      return new Promise((resolve, reject) => {
+           crypto.randomBytes(count, function (err, buff) {
+               if (err) {
+                   reject(err);
+               } else {
+                   resolve(buff.toString('binary'));
+               }
+           });
+       });
     }
 
     encode64(input, count) {


### PR DESCRIPTION
The current implementation relies on [randbytes](https://www.npmjs.com/package/randbytes). The Node Crypto API already includes a cryptographically strong version of random bytes, [randomBytes(size[, callback])](https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback), so I switched the implementation to that. The advantages being:

- one less external dependency
- works cross-platform (not just unix)
- bypasses an issue with jest and randbytes not playing well together